### PR TITLE
Make the tab close immediately

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1,3 +1,3 @@
-chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
-  if(message.closeThis) chrome.tabs.remove(sender.tab.id);
+chrome.runtime.onMessage.addListener((message, sender) => {
+  if (message.closeFigmaTab) chrome.tabs.remove(sender.tab.id);
 });

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -1,10 +1,11 @@
-(function() {
-	// Adding a delay before chacking
-	setTimeout(function(){
-		// Check if the desktop interstitial is open
-		var interstitial = window.document.querySelectorAll("*[class^=\"desktop_app_interstitial\"]")[0]
-		if(interstitial) {
-			chrome.runtime.sendMessage({closeThis: true});
-		}
-	}, 5000);
+(function () {
+  window.addEventListener("load", () => {
+    const interstitial = window.document.querySelector(
+      '*[class^="desktop_app_interstitial"]'
+    );
+
+    if (interstitial) {
+      chrome.runtime.sendMessage({ closeFigmaTab: true });
+    }
+  });
 })();


### PR DESCRIPTION
Hey there, this is a smol PR that uses `addEventListener` to close the tab immediately (rather than adding a timeout). I tested this a bunch of times and it seemed to always work, even when Figma wasn't running. I'm using this fork for myself, but feel free to close this PR if you would rather stick with the timeout :)

Thanks for the extension!