### PR TITLE
Extend URL pattern to include FigJam boards

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,7 +17,7 @@
   },
   "content_scripts": [
     {
-    "matches": ["http://*.figma.com/file/*", "https://*.figma.com/file/*"],
+    "matches": ["http://*.figma.com/file/*", "https://*.figma.com/file/*", "http://*.figma.com/board/*", "https://*.figma.com/board/*"],
      "js": ["js/content.js"],
      "run_at": "document_end"
     }


### PR DESCRIPTION
FigJam boards use `figma.com/board` not `figma.com/file`. This PR adds that additional URL pattern. 