### PR TITLE
add the new /design/ URL scheme to the manifest

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,7 +17,7 @@
   },
   "content_scripts": [
     {
-    "matches": ["http://*.figma.com/file/*", "https://*.figma.com/file/*", "http://*.figma.com/board/*", "https://*.figma.com/board/*"],
+    "matches": ["http://*.figma.com/file/*", "https://*.figma.com/file/*", "http://*.figma.com/board/*", "https://*.figma.com/board/*", "https://*.figma.com/design/*", "http://*.figma.com/design/*"],
      "js": ["js/content.js"],
      "run_at": "document_end"
     }


### PR DESCRIPTION
looks like Figma renamed figma.com/file/ to figma.com/design/, so I simply added those to the manifest, which restores functionality when I load it locally.